### PR TITLE
Change detection to always work and change polygon generation to not include extra triangles

### DIFF
--- a/addons/auto_polygon2d_triangulation/auto_poly_plugin.gd
+++ b/addons/auto_polygon2d_triangulation/auto_poly_plugin.gd
@@ -3,7 +3,7 @@ extends EditorPlugin
 
 var editor_selection := get_editor_interface().get_selection()
 var selected_polygon2d : Polygon2D = null
-var current_polygon_count : int = 0
+var previous_points : PackedVector2Array
 
 
 func _enter_tree() -> void:
@@ -12,10 +12,11 @@ func _enter_tree() -> void:
 
 
 func _process(_delta: float) -> void:
-	if selected_polygon2d :
-		if selected_polygon2d.polygon.size() != current_polygon_count:
-			triangulate_polygons(selected_polygon2d)
-			current_polygon_count = selected_polygon2d.polygon.size()
+	if selected_polygon2d == null:
+		return
+	if selected_polygon2d.polygon != previous_points:
+		triangulate_polygons(selected_polygon2d)
+	previous_points = selected_polygon2d.polygon.duplicate()
 
 
 
@@ -28,10 +29,14 @@ func _on_selection_changed() -> void:
 
 	if not selected_nodes.is_empty() and selected_nodes[0] is Polygon2D:
 		selected_polygon2d = selected_nodes[0]
-		current_polygon_count = selected_polygon2d.polygon.size()
+		triangulate_polygons(selected_polygon2d)
 	else:
 		selected_polygon2d = null
-		current_polygon_count = 0
+
+func _is_line_in_polygon(a: Vector2, b: Vector2, polygon_verts: PackedVector2Array) -> bool:
+	return Geometry2D.is_point_in_polygon(a + a.direction_to(b) * 0.01, polygon_verts) \
+		and Geometry2D.is_point_in_polygon(b + b.direction_to(a) * 0.01, polygon_verts) \
+		and Geometry2D.is_point_in_polygon((a + b) / 2, polygon_verts)
 
 func triangulate_polygons(polygon2d : Polygon2D) -> void:
 	if polygon2d.polygon.size() < 3:
@@ -39,14 +44,24 @@ func triangulate_polygons(polygon2d : Polygon2D) -> void:
 		return
 
 	polygon2d.polygons = []
-
-	var delaunay_points = Geometry2D.triangulate_delaunay(polygon2d.polygon)
-
-	for point in range(0, delaunay_points.size(), 3):
+	var points = Geometry2D.triangulate_delaunay(polygon2d.polygon)
+	var contour_polygon = polygon2d.polygon.slice(0, polygon2d.polygon.size() - polygon2d.internal_vertex_count)
+	for point in range(0, points.size(), 3):
 		var triangle = []
-		triangle.push_back(delaunay_points[point])
-		triangle.push_back(delaunay_points[point + 1])
-		triangle.push_back(delaunay_points[point + 2])
-
-		polygon2d.polygons.push_back(triangle)
+		triangle.push_back(points[point])
+		triangle.push_back(points[point + 1])
+		triangle.push_back(points[point + 2])
+		var a = polygon2d.polygon[points[point]]
+		var b = polygon2d.polygon[points[point + 1]]
+		var c = polygon2d.polygon[points[point + 2]]
+		var center = (a + b + c) / 3
+		# move points inside the triangle so we don't check for intersection with polygon edge
+		a = a - (a - center).normalized() * 0.01
+		b = b - (b - center).normalized() * 0.01
+		c = c - (c - center).normalized() * 0.01
+		# if all same points are inside polygon, then add it
+		if Geometry2D.is_point_in_polygon(a, contour_polygon) \
+			and Geometry2D.is_point_in_polygon(b, contour_polygon) \
+			and Geometry2D.is_point_in_polygon(c, contour_polygon):
+			polygon2d.polygons.push_back(triangle)
 

--- a/addons/auto_polygon2d_triangulation/auto_poly_plugin.gd
+++ b/addons/auto_polygon2d_triangulation/auto_poly_plugin.gd
@@ -19,7 +19,6 @@ func _process(_delta: float) -> void:
 	previous_points = selected_polygon2d.polygon.duplicate()
 
 
-
 func _exit_tree() -> void:
 	editor_selection.selection_changed.disconnect(self._on_selection_changed)
 
@@ -33,10 +32,18 @@ func _on_selection_changed() -> void:
 	else:
 		selected_polygon2d = null
 
-func _is_line_in_polygon(a: Vector2, b: Vector2, polygon_verts: PackedVector2Array) -> bool:
-	return Geometry2D.is_point_in_polygon(a + a.direction_to(b) * 0.01, polygon_verts) \
-		and Geometry2D.is_point_in_polygon(b + b.direction_to(a) * 0.01, polygon_verts) \
-		and Geometry2D.is_point_in_polygon((a + b) / 2, polygon_verts)
+
+func _points_are_inside_polygon(a: Vector2, b: Vector2, c: Vector2, polygon: PackedVector2Array) -> bool:
+	var center = (a + b + c) / 3
+	# move points inside the triangle so we don't check for intersection with polygon edge
+	a = a - (a - center).normalized() * 0.01
+	b = b - (b - center).normalized() * 0.01
+	c = c - (c - center).normalized() * 0.01
+	
+	return Geometry2D.is_point_in_polygon(a, polygon) \
+		and Geometry2D.is_point_in_polygon(b, polygon) \
+		and Geometry2D.is_point_in_polygon(c, polygon)
+
 
 func triangulate_polygons(polygon2d : Polygon2D) -> void:
 	if polygon2d.polygon.size() < 3:
@@ -45,23 +52,19 @@ func triangulate_polygons(polygon2d : Polygon2D) -> void:
 
 	polygon2d.polygons = []
 	var points = Geometry2D.triangulate_delaunay(polygon2d.polygon)
-	var contour_polygon = polygon2d.polygon.slice(0, polygon2d.polygon.size() - polygon2d.internal_vertex_count)
+	# Outer verticies are stored at the beginning of the PackedVector2Array
+	var outer_polygon = polygon2d.polygon.slice(0, polygon2d.polygon.size() - polygon2d.internal_vertex_count)
 	for point in range(0, points.size(), 3):
 		var triangle = []
 		triangle.push_back(points[point])
 		triangle.push_back(points[point + 1])
 		triangle.push_back(points[point + 2])
-		var a = polygon2d.polygon[points[point]]
-		var b = polygon2d.polygon[points[point + 1]]
-		var c = polygon2d.polygon[points[point + 2]]
-		var center = (a + b + c) / 3
-		# move points inside the triangle so we don't check for intersection with polygon edge
-		a = a - (a - center).normalized() * 0.01
-		b = b - (b - center).normalized() * 0.01
-		c = c - (c - center).normalized() * 0.01
-		# if all same points are inside polygon, then add it
-		if Geometry2D.is_point_in_polygon(a, contour_polygon) \
-			and Geometry2D.is_point_in_polygon(b, contour_polygon) \
-			and Geometry2D.is_point_in_polygon(c, contour_polygon):
+		
+		# only add the triangle if all points are inside the polygon
+		var a : Vector2 = polygon2d.polygon[points[point]]
+		var b : Vector2 = polygon2d.polygon[points[point + 1]]
+		var c : Vector2 = polygon2d.polygon[points[point + 2]]
+		
+		if _points_are_inside_polygon(a, b, c, outer_polygon):
 			polygon2d.polygons.push_back(triangle)
 

--- a/addons/auto_polygon2d_triangulation/plugin.cfg
+++ b/addons/auto_polygon2d_triangulation/plugin.cfg
@@ -2,6 +2,6 @@
 
 name="Auto Polygon2D Triangulation"
 description="Automatically triangulates Polygon2D nodes using Delaunay triangulation."
-author="Dylan Weremeichik (Geekforged), Max Wu (jackycute)"
-version="2023.03.08"
+author="Dylan Weremeichik (Geekforged), Max Wu (jackycute), Dragos Daian (Ughuuu)"
+version="2023.04.13"
 script="auto_poly_plugin.gd"


### PR DESCRIPTION
Use instead previous_points for change detection(get previous polygon points and check if current points are different from those). This way it's no longer "laggy" when updating polygon. When generating polygon, only use outside points for polygon generation(not internal ones). Also, when generating, make sure generated polygon is inside outline.


Without this:
<img width="356" alt="without" src="https://user-images.githubusercontent.com/2369380/231522140-c40aa549-ffa6-4d1b-8e71-8cf01f8de2ad.png">
With this change:
<img width="418" alt="with" src="https://user-images.githubusercontent.com/2369380/231522181-4f8b62b4-8515-4f53-8b9e-a77a9a98952a.png">

Also, as for realtime changing of polygon, it changes both when you select the polygon and also when you move the points(not just when you change polygon size).